### PR TITLE
Fix #5

### DIFF
--- a/dist/build.js
+++ b/dist/build.js
@@ -101,7 +101,7 @@
 
     stream.on('end', function () {
       var result = hash.digest('hex'),
-          file = filename.replace(sourceDirectory + '/', '');
+          file = path.relative(sourceDirectory, filename).replace("\\", "/");
 
       callback(null, { file: file, hash: result });
     });

--- a/dist/build.js
+++ b/dist/build.js
@@ -101,7 +101,7 @@
 
     stream.on('end', function () {
       var result = hash.digest('hex'),
-          file = path.relative(sourceDirectory, filename).replace("\\", "/");
+          file = path.relative(sourceDirectory, filename).replace(new RegExp("\\\\", "g"), "/");
 
       callback(null, { file: file, hash: result });
     });

--- a/src/build.js
+++ b/src/build.js
@@ -107,7 +107,7 @@
 
     stream.on('end', function () {
       var result = hash.digest('hex'),
-          file = filename.replace(sourceDirectory+'/', '');
+          file = path.relative(sourceDirectory, filename).replace("\\","/");
 
       callback(null, {file: file, hash: result});
     });

--- a/src/build.js
+++ b/src/build.js
@@ -107,7 +107,7 @@
 
     stream.on('end', function () {
       var result = hash.digest('hex'),
-          file = path.relative(sourceDirectory, filename).replace("\\","/");
+          file = path.relative(sourceDirectory, filename).replace(new RegExp("\\\\","g"),"/");
 
       callback(null, {file: file, hash: result});
     });


### PR DESCRIPTION
Replaced the method to get a file's relative path (now using path.relative) and, also, fixed the Windows issue #5 