### PR TITLE
Deploy via FTP

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "airbnb",
+  "extends": "airbnb/base",
   "env": {
     "browser": true,
     "mocha": true,
@@ -10,6 +10,7 @@
     "sinon": true
   },
   "rules": {
+    "no-console": 0,
     "no-use-before-define": [2, "nofunc"],
     "comma-dangle": [2, "always-multiline"],
     "block-scoped-var": 0 // TEMPORARY until issue in ESLint is fixed

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "chai": "^3.2.0",
     "eslint": "^0.24.1",
     "eslint-config-airbnb": "0.0.7",
-    "eslint-plugin-react": "^3.1.0",
     "jscs": "^2.0.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "es6-promise": "^2.3.0",
     "express": "^4.13.1",
     "fs-extra": "^0.22.1",
+    "ftp-client": "^0.2.2",
+    "hidefile": "^1.1.0",
     "lodash": "^3.10.0",
+    "minimatch": "^3.0.0",
     "ngrok": "^0.1.99",
     "prompt": "^0.2.14",
     "q": "^1.4.1",
@@ -46,9 +49,7 @@
     "s3": "^4.4.0",
     "socket.io": "^1.3.6",
     "watch": "^0.16.0",
-    "yargs": "^3.16.1",
-    "minimatch": "^3.0.0",
-    "hidefile": "^1.1.0"
+    "yargs": "^3.16.1"
   },
   "devDependencies": {
     "babel": "^5.8.19",

--- a/package.json
+++ b/package.json
@@ -52,11 +52,10 @@
   },
   "devDependencies": {
     "babel": "^5.8.19",
-    "babel-eslint": "^4.0.5",
     "babel-jscs": "^2.0.3",
     "chai": "^3.2.0",
-    "eslint": "^0.24.1",
-    "eslint-config-airbnb": "0.0.7",
+    "eslint": "^1.0.0",
+    "eslint-config-airbnb": "1.0.0",
     "jscs": "^2.0.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.4.2",

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -13,6 +13,11 @@
     execute: execute
   };
 
+  const deploymentModes = {
+    s3: uploadToS3,
+    ftp: uploadToFTP
+  };
+
   function execute(context) {
     var executeDfd = Q.defer();
 
@@ -52,15 +57,12 @@
       process.exit(0);
     }
 
-    // console.log('LoginInfo: ', loginInfo);
-    // console.log('Config: ', config);
-    switch (loginInfo.pushMode) {
-      case 'ftp':
-        return uploadToFTP(context, config, loginInfo.ftp);
-      case 's3':
-        return uploadToS3(context, config, loginInfo.s3);
-      default:
-        throw new Error('unsupported push mode.');
+    const pushMode = loginInfo.pushMode;
+    try {
+      return deploymentModes[pushMode](context, config, loginInfo[pushMode]);
+    } catch (e) {
+      console.error('unsupported deployment method ', e);
+      process.exit(0);
     }
   }
 

--- a/src/init.js
+++ b/src/init.js
@@ -18,13 +18,13 @@ const name = {
 };
 
 const s3bucket = {
-  description: 'Amazon S3 Bucket name (required for cordova-hcp deploy)',
+  description: 'Amazon S3 Bucket name (leave it blank to use an FTP)',
   pattern: /^[a-zA-Z\-0-9\.]+$/,
   message: 'Name must be only letters, numbers, or dashes',
 };
 
 const s3region = {
-  description: 'Amazon S3 region (required for chcp deploy)',
+  description: 'Amazon S3 region (leave it blank to use an FTP)',
   pattern: /^(us-east-1|us-west-2|us-west-1|eu-west-1|eu-central-1|ap-southeast-1|ap-southeast-2|ap-northeast-1|sa-east-1)$/,
   default: 'us-east-1',
   message: 'Must be one of: us-east-1, us-west-2, us-west-1, eu-west-1, eu-central-1, ap-southeast-1, ap-southeast-2, ap-northeast-1, sa-east-1',


### PR DESCRIPTION
Fixes #4 

This PR breaks the current JSON schema of the `.chcplogin` file to support multiple deployment modes.
### FTP schema

```
{
  "pushMode": "ftp",
  "ftp": {
    "host": "host",
    "port": "21",
    "path": "/public_html/...",
    "username": "username",
    "password": "password"
  }
}
```
### Amazon s3 login

```
{
  "pushMode": "s3",
  "s3": {
    "key": "accessKey",
    "secret": "secretKey"
  }
}
```
