### PR TITLE
added options to disable using public tunnel

### DIFF
--- a/dist/server.js
+++ b/dist/server.js
@@ -77,7 +77,7 @@
       return build(chcpContext);
     });
 
-    funcs.push(function () {
+    funcs.push(function (config) {
       if (disablePublicTunnel) {
         updateLocalEnv({ content_url: config.content_url });
       }

--- a/dist/server.js
+++ b/dist/server.js
@@ -11,6 +11,7 @@
       express = require('express'),
       app = express(),
       assetPort = process.env.PORT || 31284,
+      disablePublicTunnel = process.env.DISABLE_PUBLIC_TUNNEL || false,
       compression = require('compression'),
       build = require('./build.js').execute,
       minimatch = require('minimatch'),
@@ -44,14 +45,17 @@
         funcs = [];
 
     funcs.push(function () {
+      if (disablePublicTunnel) return;
       return publicTunnel(assetPort);
     });
 
     funcs.push(function (content_url) {
       var dfd = Q.defer();
 
-      opts.content_url = content_url;
-      chcpContext.argv.content_url = content_url;
+      if (!disablePublicTunnel) {
+        opts.content_url = content_url;
+        chcpContext.argv.content_url = content_url;
+      }
 
       dfd.resolve();
       return dfd.promise;
@@ -74,8 +78,11 @@
     });
 
     funcs.push(function () {
+      if (disablePublicTunnel) {
+        updateLocalEnv({ content_url: config.content_url });
+      }
       console.log('cordova-hcp local server available at: ' + opts.local_url);
-      console.log('cordova-hcp public server available at: ' + opts.content_url);
+      console.log('cordova-hcp public server available at: ' + config.content_url);
     });
 
     return funcs.reduce(Q.when, Q('initial'));

--- a/src/server.js
+++ b/src/server.js
@@ -76,7 +76,7 @@
       return build(chcpContext);
     });
 
-    funcs.push(function(){
+    funcs.push(function(config){
       if (disablePublicTunnel) {
         updateLocalEnv({ content_url: config.content_url })
       }

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,7 @@
       express = require('express'),
       app = express(),
       assetPort = process.env.PORT || 31284,
+      disablePublicTunnel = process.env.DISABLE_PUBLIC_TUNNEL || false,
       compression = require('compression'),
       build = require('./build.js').execute,
       minimatch = require('minimatch'),
@@ -42,14 +43,18 @@
       funcs = [];
 
     funcs.push(function(){
+      if (disablePublicTunnel)
+        return;
       return publicTunnel(assetPort);
     });
 
     funcs.push(function(content_url) {
       var dfd = Q.defer();
 
-      opts.content_url = content_url;
-      chcpContext.argv.content_url = content_url;
+      if (!disablePublicTunnel) {
+        opts.content_url = content_url;
+        chcpContext.argv.content_url = content_url;
+      }
 
       dfd.resolve();
       return dfd.promise;
@@ -72,8 +77,11 @@
     });
 
     funcs.push(function(){
-      console.log('cordova-hcp local server available at: '+ opts.local_url);
-      console.log('cordova-hcp public server available at: ' + opts.content_url);
+      if (disablePublicTunnel) {
+        updateLocalEnv({ content_url: config.content_url })
+      }
+      console.log('cordova-hcp local server available at: ' + opts.local_url);
+      console.log('cordova-hcp public server available at: ' + config.content_url);
     });
 
     return funcs.reduce(Q.when, Q('initial'));


### PR DESCRIPTION
local development mode is unable to use our own server currently, it always use ngrok to host public server.

I have added options to disable using public tunnel for local development mode
and use the content_url from cordova-hcp.json as public server