### PR TITLE
Adding Manifest Signatures

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -162,7 +162,7 @@
       };
 
     } catch(e) {
-      console.log('Error with keyfile', signingPrivateKeyFile);
+      console.log('Error with keyfile', signingPrivateKeyFilePath);
       process.exit(1);
     }
 

--- a/src/build.js
+++ b/src/build.js
@@ -154,7 +154,7 @@
 
     try {
       var signingKey = fs.readFileSync(signingPrivateKeyFilePath, 'utf8');
-      var contentSignature = sign.sign(signingKey, 'hex');
+      var contentSignature = sign.sign(signingKey, 'base64');
 
       var signature = {
         'algorithm': signatureAlgorithm,

--- a/src/context.js
+++ b/src/context.js
@@ -12,6 +12,7 @@
       'node_modules\\*',
       'chcp.json',
       'chcp.manifest',
+      'chcp.signature',
       '.chcp*',
       '.gitignore',
       '.gitkeep',

--- a/src/context.js
+++ b/src/context.js
@@ -31,6 +31,7 @@
     this.defaultConfig = DEFAULT_CLI_CONFIG;
     this.sourceDirectory = getSourceDirectory(argv);
     this.manifestFilePath = path.join(this.sourceDirectory, 'chcp.manifest');
+    this.manifestSignatureFilePath = path.join(this.sourceDirectory, 'chcp.signature');
     this.projectsConfigFilePath = path.join(this.sourceDirectory, 'chcp.json');
     this.ignoredFiles = getIgnoredFiles();
   };


### PR DESCRIPTION
To meet the security requirements of my organization, we needed to implement manifest signing for hot code pushes. 

This pull request adds support for the following in the CLI:
1. Using alternate hash functions inside chcp.manifest - the current default (md5) is just fine for detecting normal changes, but it's not secure from intentional tampering. I have added support for sha256 - this can be opted into by setting the "hash_algorithm": "sha256" in cordova-hcp.json or passing the --hash_alogrithm CLI argument
2. Signing chcp.manifest via CLI argument --signing_private_key_file=/path/to/rsa_rivate_key - this will generate a new file in the bundle directory, chcp.signature

Full usage example:
1. Generate 2048-bit RSA private key
   `openssl genrsa -out private.pem 2048`
2. Build a signed update bundle with sha256 signatures
   `cordova-hcp build --signing_private_key_file=private.pem --hash_algorithm=sha256`

TODO: Update this pull request with a link to the corresponding pull with support in cordova-hot-code-push

Notes: 
- Alternate hash algorithms is independent of the signature feature - you may switch hash algorithm to sha256 without signing builds and vice versa
- Switching hash algorithm is a breaking change - existing clients which were build with only md5 support will not recognize the new hashes and will treat all files as corrupted
- Signing manifests is a backwards-compatible change - existing clients which do not support validating manifest signatures will simply ignore the chcp.signature file

Please review these changes and let me know what I should change, test, or fix before you are comfortable accepting this pull.
