### PR TITLE
Add directoryFilter to correctly filter folders listed in .chcpignore

### DIFF
--- a/dist/deploy.js
+++ b/dist/deploy.js
@@ -82,7 +82,8 @@
       acl: 'public-read',
       headers: {
         CacheControl: 'no-cache, no-store, must-revalidate',
-        Expires: 0
+        Expires: 0,
+        ContentEncoding: "gzip"
       },
       concurrency: 20
     }).on('data', function (file) {

--- a/dist/deploy.js
+++ b/dist/deploy.js
@@ -69,7 +69,8 @@
 
     var files = readdirp({
       root: context.sourceDirectory,
-      fileFilter: ignore
+      fileFilter: ignore,
+      directoryFilter: ignore
     });
 
     var uploader = s3sync({

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -76,7 +76,8 @@
       acl: 'public-read',
       headers: {
         CacheControl: 'no-cache, no-store, must-revalidate',
-        Expires: 0
+        Expires: 0,
+        ContentEncoding: "gzip"
       },
       concurrency: 20
     }).on('data', function(file) {

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -63,7 +63,8 @@
 
     var files = readdirp({
       root: context.sourceDirectory,
-      fileFilter: ignore
+      fileFilter: ignore,
+      directoryFilter: ignore
     });
 
     var uploader = s3sync({


### PR DESCRIPTION
Hey there @nikDemyankov I know `cordova-hot-code-push-cli` is an old project now and you probably don't care much for the new PRs :) but just switched one of the older projects to your plugin and ran into an issue where the folders listed in `.chcpignore` were still being deployed to s3. This PR should fix it. I think this is somehow related to #49. Cheers.